### PR TITLE
Updated indy-sdk and postgres plug-in

### DIFF
--- a/1.6-ew/Dockerfile.ubuntu
+++ b/1.6-ew/Dockerfile.ubuntu
@@ -108,7 +108,10 @@ RUN curl -o rustup https://sh.rustup.rs && \
     curl -o indy-crypto/indy-crypto.tar.gz "${indy_crypto_url}" && \
     cd indy-sdk && \
     tar xzf indy-sdk.tar.gz && \
-    cd */libindy && \
+    cd */libindy-common && \
+    $HOME/.cargo/bin/cargo build ${indy_build_flags} && \
+    mv target/*/libindy_common.so "$HOME/.local/lib" && \
+    cd ../libindy && \
     $HOME/.cargo/bin/cargo build ${indy_build_flags} && \
     mv target/*/libindy.so "$HOME/.local/lib" && \
     tar czvf python3-indy.tgz -C ../wrappers/python . && \
@@ -118,7 +121,7 @@ RUN curl -o rustup https://sh.rustup.rs && \
     mv target/*/indy-cli "$HOME/.local/bin" && \
     cd ../samples/storage/storage-postgres && \
     $HOME/.cargo/bin/cargo build ${indy_build_flags} && \
-    mv target/*/libindystrgpostgres* "$HOME/.local/lib" && \
+    mv target/*/libindystrgpostgres.so "$HOME/.local/lib" && \
     cd $HOME/indy-crypto && \
     tar xzf indy-crypto.tar.gz && \
     cd */libindy-crypto && \

--- a/make_image.py
+++ b/make_image.py
@@ -49,8 +49,8 @@ VERSIONS = {
     "1.6-ew": {
         "version": "1.6-ew-10",
         "args": {
-            # bcgov postgres_storage branch
-            "indy_sdk_url": "https://codeload.github.com/bcgov/indy-sdk/tar.gz/76a4ed74e08f0e81ff792a795538deb099de94a1",
+            # bcgov postgres_plugin branch
+            "indy_sdk_url": "https://codeload.github.com/bcgov/indy-sdk/tar.gz/88424a10f53a7e47c49143b9866a0d531c1d9420",
             # 0.4.5
             "indy_crypto_url": "https://codeload.github.com/hyperledger/indy-crypto/tar.gz/a2864642430064c6f00902e9b999cc6356eed9f1",
         }


### PR DESCRIPTION
Removed postgres plug-in dependency on libindy

New EW von-image size is 408 MB
