### PR TITLE
Add flag --vonx to force re-install of von-x

### DIFF
--- a/1.6-ew/Dockerfile.ubuntu
+++ b/1.6-ew/Dockerfile.ubuntu
@@ -221,6 +221,14 @@ ENV LD_LIBRARY_PATH="$HOME/.local/lib:$LD_LIBRARY_PATH"
 
 USER $user
 
+# Re-Install von-x library
+ARG CACHEBUST=1
+ADD requirements-vonx.txt .
+RUN if [ "$VONX_FORCE" = "True" ]; then \
+        pip uninstall -y -r requirements-vonx.txt && \
+        pip install --no-cache-dir --force-reinstall -r requirements-vonx.txt; \
+fi
+
 # Create standard directories to allow volume mounting and set permissions
 # Note: PIP_NO_CACHE_DIR environment variable should be cleared to allow caching
 RUN mkdir -p \

--- a/1.6-ew/requirements-vonx.txt
+++ b/1.6-ew/requirements-vonx.txt
@@ -1,0 +1,2 @@
+#vonx==1.4.4
+git+git://github.com/ianco/von-x.git#egg=vonx

--- a/make_image.py
+++ b/make_image.py
@@ -5,6 +5,7 @@ import os.path
 import re
 import subprocess
 import sys
+import random
 
 VERSIONS = {
     "dev-441": {
@@ -77,6 +78,7 @@ parser.add_argument('--python', help='use a specific python version')
 parser.add_argument('--push', action='store_true', help='push the resulting image')
 parser.add_argument('-q', '--quiet', action='store_true', help='suppress output from docker build')
 parser.add_argument('--release', dest='debug', action='store_false', help='produce a release build of libindy')
+parser.add_argument('--vonx', action='store_true', help='force re-install of von-x from library in requirements-vonx.txt')
 parser.add_argument('--s2i', action='store_true', help='build the s2i image for this version')
 parser.add_argument('--squash', action='store_true', help='produce a smaller image')
 parser.add_argument('--test', action='store_true', help='perform tests on docker image')
@@ -142,6 +144,9 @@ if args.no_cache:
 if args.squash:
     cmd_args.append('--squash')
 cmd_args.extend(['-t', tag])
+if args.vonx:
+    cmd_args.extend(['--build-arg', 'CACHEBUST=' + str(random.randint(100000,999999))])
+    cmd_args.extend(['--build-arg', 'VONX_FORCE="True"'])
 cmd_args.append(target)
 cmd = ['docker', 'build'] + cmd_args
 if args.dry_run:


### PR DESCRIPTION
For example if you run:

python3 make_image.py --py36 --s2i 1.6-ew --vonx

It will force a re-install of von-x based on the repo listed in requirements-vonx.txt

(Allows development to point to a different repo, and quick re-build of von-image with updated von-x)
