### PR TITLE
Update image 1.7-ew with patched von_anchor to prevent ledger writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 python.env
 .DS_Store
+venv

--- a/1.10/Dockerfile.ubuntu
+++ b/1.10/Dockerfile.ubuntu
@@ -32,7 +32,7 @@ RUN apt-get update -y && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG nacl_lib_ver=1.0.16
+ARG nacl_lib_ver=1.0.18
 
 # Build and install libsodium library
 RUN curl -o libsodium-${nacl_lib_ver}.tar.gz \

--- a/1.7-ew/Dockerfile.ubuntu
+++ b/1.7-ew/Dockerfile.ubuntu
@@ -34,7 +34,7 @@ RUN apt-get update -y && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG nacl_lib_ver=1.0.16
+ARG nacl_lib_ver=1.0.18
 
 # Build and install libsodium library
 RUN curl -o libsodium-${nacl_lib_ver}.tar.gz \
@@ -223,7 +223,7 @@ ARG CACHEBUSTVX="1"
 ARG VONX_FORCE=False
 ADD requirements-vonx.txt .
 RUN if [ "${VONX_FORCE}" = "True" ]; then \
-   pip uninstall -y -r requirements-vonx.txt && \
+   pip uninstall -y --no-cache-dir -r requirements-vonx.txt && \
    pip install --no-cache-dir --force-reinstall -r requirements-vonx.txt; \
 fi
 

--- a/1.7-ew/requirements-vonx.txt
+++ b/1.7-ew/requirements-vonx.txt
@@ -1,4 +1,3 @@
-#vonx==1.4.6
-#von-anchor==1.7.1
-#git+git://github.com/ianco/von_anchor.git#egg=von-anchor
-git+git://github.com/ianco/von-x.git#egg=vonx
+# build as follows:
+# python ./make_image.py --build-arg VONX_FORCE=True --py36 --s2i 1.7-ew
+git+git://github.com/PSPC-SPAC-buyandsell/von_anchor.git@ian-1.7.2020-02-11#egg=von-anchor

--- a/make_image.py
+++ b/make_image.py
@@ -8,10 +8,11 @@ import random
 
 VERSIONS = {
     "1.7-ew": {
-        "version": "1.7-ew-0",
+        "version": "1.7-ew-1",
         "args": {
-            # bcgov postgres_plugin branch
-            "indy_sdk_url": "https://codeload.github.com/bcgov/indy-sdk/tar.gz/c4a0249cf9d06dbc1c3c1533e8bf1e0c5946dbb4",
+            # 1.14.1 release
+            "indy_sdk_url": "https://codeload.github.com/ianco/indy-sdk/tar.gz/4825ab317d541f89142ac108e230d09ff76c9969",
+            "rust_version": "1.37.0",
             # 0.5.0
             "indy_crypto_url": "https://codeload.github.com/hyperledger/indy-crypto/tar.gz/c323bd0046e4e7da936ad1682a401c557c74345b",
         },


### PR DESCRIPTION
Signed-off-by: Ian Costanzo <ian@anon-solutions.ca>

Build the patched 1.7-ew image as follows:

`python ./make_image.py --build-arg VONX_FORCE=True --py36 --s2i 1.7-ew`
