### PR TITLE
Fix node startup crashing issue with large ledgers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ The following images include Python 3.6, the Indy SDK library and Python wrapper
 
 ## Indy Node images
 
-These images include the Indy Node library for hosting an Indy ledger node or pool. Also included are Python 3.5, the Indy SDK library and Python wrapper, Indy CLI, and the `postgres_storage` wallet storage plugin. They form the basis of `von-network`.
+These images include the Indy Node library for hosting an Indy ledger node or pool. Also included are Python 3.6, the Indy SDK library and Python wrapper, Indy CLI, and the `postgres_storage` wallet storage plugin. They form the basis of `von-network`.
 
 | Image tag         | indy-node version          | indy-sdk version           | python version             |
 |-------------------|----------------------------|----------------------------|----------------------------|
+| node-1.12-4       | 1.12.4                     | 1.16.0                     | 3.6.9                      |
 | node-1.12-3       | 1.12.3                     | 1.15.0                     | 3.6.9                      |
 | node-1.12-2       | 1.12.2                     | 1.14.1                     | 3.6.9                      |
 | node-1.9-4        | 1.9.2 (gettext added)      | 1.11.1                     | 3.5.7                      |

--- a/make_node_image.py
+++ b/make_node_image.py
@@ -37,11 +37,12 @@ VERSIONS = {
         "path": "node-1.12",
         "version": "node-1.12-4",
         "args": {
-            # 1.15.0 release
-            "indy_sdk_url": "https://codeload.github.com/hyperledger/indy-sdk/tar.gz/f85afd2f94959eb59522e5dda160d2c7fdd1a4ba",
+            # 1.16.0 release
+            "indy_sdk_url": "https://codeload.github.com/hyperledger/indy-sdk/tar.gz/b4b330ef326958d593ab42e25679c2dcd655494c",
             # 0.3.2
             "ursa_url": "https://codeload.github.com/hyperledger/ursa/tar.gz/394bcdf1413ac41793e96175d46d745ed6ffd970",
-            "rust_version": "1.40.0",
+            "rocksdb_lib_ver":"5.8.fb",
+            "rust_version": "1.46.0",
         },
         "python_version": PY_36_VERSION,
     },

--- a/node-1.12/requirements.txt
+++ b/node-1.12/requirements.txt
@@ -4,5 +4,7 @@ aiosqlite~=0.13.0
 base58~=1.0.0
 cchardet~=2.1.0
 rlp~=0.6.0
+cython
+python-rocksdb==0.7.0
 indy-node==1.12.4
 git+https://github.com/hyperledger/indy-plenum.git@0bbf5c84fc11290cee4272649eb8288de0fa756d#egg=indy-plenum


### PR DESCRIPTION
- Downgrade to `RocksDB v5.8.8` due to crashes on node startup with large domain ledgers.  `RocksDB v5.8.8` is the version used with the official `indy-node` and `indy-plenum` 1.12.4 releases.

Upgrades:
 - `indy-sdk` 1.16.0
 - `python-rocksdb` 0.7.0
 - `python-ursa` 0.1.1
 - `rust` 1.46.0

Signed-off-by: Wade Barnes <wade@neoterictech.ca>