### PR TITLE
changes to compile for linux/arm64 & Apple M1

### DIFF
--- a/node-1.12/Dockerfile.ubuntu
+++ b/node-1.12/Dockerfile.ubuntu
@@ -1,4 +1,5 @@
-FROM ubuntu:18.04 as builder
+ARG platform=linux/amd64
+FROM --platform=${platform} ubuntu:18.04 as builder
 
 ARG user=indy
 ENV HOME="/home/$user"
@@ -157,7 +158,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 
 ## Start fresh (new image) ##
-FROM ubuntu:18.04
+FROM --platform=${platform} ubuntu:18.04 
 
 
 ARG uid=1001


### PR DESCRIPTION
**Changes to compile/run on Apple M1 silicon.** 
Based on changes in nebucaz/indy-sdk where fixes in postgres_storage have been implemented to be able to compile on Ubuntu 20.04 aarch64 (linux/arm64) architecture

Dockerfile.ubuntu
- added `ARG platform`
- `FROM` uses `--platform` attribute

make_node_image.py
- added new version 1.12a to define nebucaz/indy-sdk as sources of the indy-sdk
- changes in python script to pass platform as build-arg

**Create image for arm64 platforms:**
./make_node_image.py 1.12a --release --platform linux/arm64/v8 --name <user>/von-image --py36 -t <user>/von-image:node-1.12-4-arm64 -f node-1.12/Dockerfile.ubuntu --push

**Create image for amd64 platforms:**
./make_node_image.py 1.12a --release --platform linux/amd64 --name <user>/von-image --py36 -t <user>/von-image:node-1.12-4-amd64 -f node-1.12/Dockerfile.ubuntu --push

Tests:
- successfully built for arm64
- run von-network
- wrote endorser DID
- created walled

```
von-network$ ./manage \                                                 
  indy-cli --config /tmp/cliconfig.json start-session \
  walletName=local_net_trustee_wallet \
  poolName=local_net \
  useDid=wwZywzAXTQXqD5X1CxeQy

walletName=local_net_trustee_wallet poolName=local_net useDid=wwZywzAXTQXqD5X1CxeQy"
Creating von_client_run ... done
"for_session" is used as transaction author agreement acceptance mechanism
load-plugin library=libindystrgpostgres.so initializer=postgresstorage_init
Plugin has been loaded: "libindystrgpostgres.so"

pool connect local_net
Pool "local_net" has been connected

-wallet attach local_net_trustee_wallet storage_type=default storage_config={}
Wallet "local_net_trustee_wallet" has been attached

wallet open local_net_trustee_wallet key storage_credentials={}
Enter value for key:

Wallet "local_net_trustee_wallet" has been opened

did use wwZywzAXTQXqD5X1CxeQy
Did "wwZywzAXTQXqD5X1CxeQy" has been set as active

pool(local_net):local_net_trustee_wallet:did(wwZ...eQy):indy> ledger get-nym did=wwZywzAXTQXqD5X1CxeQy
Following NYM has been received.
Metadata:
+-----------------------+-----------------+---------------------+---------------------+
| Identifier            | Sequence Number | Request ID          | Transaction time    |
+-----------------------+-----------------+---------------------+---------------------+
| wwZywzAXTQXqD5X1CxeQy | 6               | 1638540086294760376 | 2021-12-03 13:39:41 |
+-----------------------+-----------------+---------------------+---------------------+
Data:
+------------------------+-----------------------+---------------------------------------------+----------+
| Identifier             | Dest                  | Verkey                                      | Role     |
+------------------------+-----------------------+---------------------------------------------+----------+
| V4SGRU86Z58d6TV7PBUe6f | wwZywzAXTQXqD5X1CxeQy | WwnibEhX2zZVpdij7FHamSBaGdJR9BQ9Vy529SXfveP | ENDORSER |
+------------------------+-----------------------+---------------------------------------------+----------+
pool(local_net):local_net_trustee_wallet:did(wwZ...eQy):indy> exit
Wallet "local_net_trustee_wallet" has been closed
Pool "local_net" has been disconnected
Goodbye...
```

Please re-test creation of amd64 image because it does not work on my Apple M1 